### PR TITLE
Refactor GridTable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,11 +36,28 @@ const App: FunctionalComponent<TProps> = ({setRow, setDataArr, dataArr,  row}) =
         && (!dateFilter.to || ctime <= dateFilter.to)
     }), [dataArr, dateFilter])
 
+  const columnNames = [
+    {id: 'svcId',    name: '№'},
+    {id: 'ctime',    name: 'Дата'},
+    {id: 'svcType',  name: 'Тип'},
+    {id: 'userName', name: 'Оператор'},
+    {id: 'feedback', name: 'Оценка'},
+    {id: 'comment',  name: 'Комментарий'}
+  ]
+
   return (
     <div class='app'>
       <div className='main-table'>
         <FilterDate to={dateFilter.to} from={dateFilter.from} onChange={setDateFilter}/>
-        {!!filteredData ? <GridTable dataArr={filteredData} selected={row} onRow={setRow}/> : 'Initializing'}
+        {!!filteredData
+          ? <GridTable
+              columnNames={columnNames}
+              data={filteredData}
+              selected={row}
+              onRow={setRow}
+            />
+          : 'Initializing'
+        }
       </div>
       <div className='additional-table'>
         {!!row && <AdditionalTable row={row}/>}

--- a/src/components/GridTable/index.scss
+++ b/src/components/GridTable/index.scss
@@ -20,3 +20,13 @@ button {
     }
   }
 }
+
+.gridjs-tr:hover {
+  .gridjs-td:not(.gridjs-message) {
+    background-color: #bfffbf;
+  }
+}
+
+.gridjs-td:not(.gridjs-message) {
+  cursor: pointer;
+}

--- a/src/components/GridTable/index.tsx
+++ b/src/components/GridTable/index.tsx
@@ -8,69 +8,51 @@ import 'gridjs/dist/theme/mermaid.min.css'
 import './index.scss'
 
 type TProps = {
-  dataArr: TDataArr
+  data: TDataArr
+  columnNames: {id: string, name: string}[]
   selected: TRow
   onRow: (row: TRow) => void
 }
 
-const GridTable: FunctionalComponent<TProps> = ({selected, dataArr, onRow}) => {
+const GridTable: FunctionalComponent<TProps> = ({data, columnNames, selected, onRow}) => {
   const wrapperRef = useRef(null)
   const [gridObj, setGridObj] = useState(null)
 
-  const dataName: TDataNames = {
-    svcId: '№',
-    ctime: 'Дата',
-    svcType: 'Тип',
-    userName: 'Оператор',
-    feedback: 'Оценка',
-    comment: 'Комментарий'
-  }
+  const config = () => {
+    const formatter = (cell: string, row: TRow) =>
+      selected && selected.cells[0].data === row.cells[0].data
+        ? <strong>{cell}</strong>
+        : cell
 
-  const renameKeys = (obj: TData, newKeys: TDataNames) => {
-    const keyValues = Object.keys(obj).map((key: keyof TDataNames) => {
-      const newKey = newKeys[key] || key
-      return { [newKey]: obj[key] }
-    })
-    return Object.assign({}, ...keyValues)
+    return {
+      data,
+      columns: columnNames.map((col) => ({formatter, ...col}))
+    }
   }
-
-  const dataKeysRename = ():TDataArr => dataArr.map(obj => renameKeys(obj, dataName))
 
   useEffect(() => {
     const grid = new Grid({
-      data: dataKeysRename(),
+      data,
       search: true,
       sort: true,
       language: {
         search: {
           placeholder: '🔍 Поиск...'
         }
-      },
-      className: {
-        td: cn({'grid-td': dataArr.length})
       }
-    }).render(wrapperRef.current)
+    })
+    grid.updateConfig(config())
+    grid.render(wrapperRef.current)
 
     grid.on('rowClick', (_, row) => onRow(row))
     setGridObj(grid)
   }, [])
 
-  useEffect(() => {
-    const formatter = (cell: string, row: TRow) =>
-      selected && selected.cells[0].data === row.cells[0].data
-        ? <strong>{cell}</strong>
-        : cell
-
-    const columns = Object.values(dataName).map((name: string) => ({name, formatter}))
-
-    const className = {td: cn({'grid-td': dataArr.length})}
-    
-    gridObj && gridObj.updateConfig({data: dataKeysRename(), columns, className}).forceRender()
-
-  }, [dataArr, selected])
+  useEffect(
+    () => gridObj && gridObj.updateConfig(config()).forceRender(),
+    [data, selected, columnNames])
 
   return <div ref={wrapperRef}/>
-
 }
 
 export default GridTable

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -52,15 +52,6 @@ span {
   float: right;
 }
 
-.gridjs-tr:hover {
-  .grid-td {
-    background-color: #bfffbf;
-  }
-}
-
-.grid-td {
-  cursor: pointer;
-}
 
 .sett {
   padding: 50px;


### PR DESCRIPTION
- Вынес названия колонок из `GridTable`
- Переименовал `dataArr` в `data`. Добавление префикса/постфикса с типом в название переменной называется ["венгерская нотация"](https://ru.wikipedia.org/wiki/%D0%92%D0%B5%D0%BD%D0%B3%D0%B5%D1%80%D1%81%D0%BA%D0%B0%D1%8F_%D0%BD%D0%BE%D1%82%D0%B0%D1%86%D0%B8%D1%8F) это было популярно в сишечке лет 30 назад, сейчас считается плохим тоном. Так же следует поступить и с префиксом `T` для типов.
- Вынес стили для подсветки `:hover` в `GridTable/index.scss`. Они больше относятся к таблице чем к приложению вцелом.
- Использование модификатора `:not(.gridjs-message)` позволяет избавиться от динамического изменения классов.